### PR TITLE
Remove <bits/stdc++.h> include that destroyed clang compatibility

### DIFF
--- a/wm_string.cpp
+++ b/wm_string.cpp
@@ -1,4 +1,3 @@
-#include <bits/stdc++.h>
 #include <random>
 #include "dynamic/dynamic.hpp"
 


### PR DESCRIPTION
Seems to compile fine by simply removing it.