### PR TITLE
Add in <chrono> include to restore GCC build

### DIFF
--- a/wm_string.cpp
+++ b/wm_string.cpp
@@ -1,4 +1,5 @@
 #include <random>
+#include <chrono>
 #include "dynamic/dynamic.hpp"
 
 using namespace std;


### PR DESCRIPTION
Looks like my fix in https://github.com/vgteam/DYNAMIC/pull/5 only works for clang.